### PR TITLE
exclude maven metadata from sources dependencies fix #24

### DIFF
--- a/apache-jsp/pom.xml
+++ b/apache-jsp/pom.xml
@@ -30,6 +30,7 @@
               <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
               <outputDirectory>${project.build.directory}/sources</outputDirectory>
               <excludeArtifactIds>ecj</excludeArtifactIds>
+              <excludes>META-INF/maven/</excludes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
fix #24
Signed-off-by: olivier lamy <olamy@apache.org>