### PR TITLE
Projects have no src/main/java tree, they cannot use default jar build lifecycle

### DIFF
--- a/apache-el/pom.xml
+++ b/apache-el/pom.xml
@@ -8,7 +8,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>apache-el</artifactId>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
   <name>MortBay :: Apache EL :: API and Implementation</name>
 
   <build>

--- a/apache-jsp/pom.xml
+++ b/apache-jsp/pom.xml
@@ -8,7 +8,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>apache-jsp</artifactId>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
   <name>MortBay :: Apache Jasper :: JSP Implementation</name>
 
   <build>

--- a/taglibs-standard/pom.xml
+++ b/taglibs-standard/pom.xml
@@ -8,7 +8,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>taglibs-standard</artifactId>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
   <name>MortBay :: Apache Taglibs Standard :: API and Implementation</name>
 
   <build>


### PR DESCRIPTION
This is to fix the build issue ...

```
[INFO] Replacing original artifact with shaded artifact.
[INFO] Replacing /home/joakim/code/jetty/github/jasper-jsp/apache-el/target/apache-el-10.0.0-SNAPSHOT.jar with /home/joakim/code/jetty/github/jasper-jsp/apache-el/target/apache-el-10.0.0-SNAPSHOT-shaded.pom
[INFO] 
[INFO] --- maven-jar-plugin:3.2.0:jar (default-jar) @ apache-el ---
[WARNING] JAR will be empty - no content was marked for inclusion!
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Jetty :: Jasper :: Project 10.0.0-SNAPSHOT:
[INFO] 
[INFO] Jetty :: Jasper :: Project ......................... SUCCESS [  6.947 s]
[INFO] MortBay :: Apache EL :: API and Implementation ..... FAILURE [  1.304 s]
[INFO] MortBay :: Apache Jasper :: JSP Implementation ..... SKIPPED
[INFO] MortBay :: Apache Taglibs Standard :: API and Implementation SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.912 s
[INFO] Finished at: 2021-02-17T09:13:06-06:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-jar-plugin:3.2.0:jar (default-jar) on project apache-el: You have to use a classifier to attach supplemental artifacts to the project instead of replacing them. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :apache-el
```

This because these projects have no `src/main/java` tree, they are not `<packaging>jar</packaging>` and cannot use the default jar lifecycle in maven.


Signed-off-by: Joakim Erdfelt <joakim.erdfelt@gmail.com>