### PR TITLE
Update maven-bundle-plugin to 5.1.9 to allow JDK 17+ to be used to build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,9 +296,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <!-- keep this version at 4.0.0, as upgrade breaks manifest generation.
-               version 4.0.0 is also incompatible with JDK 17+ -->
-          <version>4.0.0</version>
+          <version>5.1.9</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Update the maven-bundle-plugin to allow JDK17+ to be used.

The original JDK11 (with m-bundle-p v4.0.0) manifest looks like this ...

**apache-el-<ver>.jar**

```
Manifest-Version: 1.0
Automatic-Module-Name: org.mortbay.apache.el
Bnd-LastModified: 1701872744230
Build-Jdk: 11.0.20.1
Built-By: joakim
Bundle-Classpath: .
Bundle-Description: A rebundling of Apache Tomcat Jasper to remove the t
 omcat server dependencies,    so that the JSP engine can be used by the
  Eclipse Jetty project.
Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
Bundle-ManifestVersion: 2
Bundle-Name: Mortbay Apache EL API and Implementation
Bundle-RequiredExecutionEnvironment: JavaSE-1.7
Bundle-SymbolicName: org.mortbay.jasper.apache-el
Bundle-Version: 10.0.27
Created-By: Apache Maven Bundle Plugin
Export-Package: jakarta.el;version="4.0.0.SNAPSHOT",org.apache.el;versio
 n="10.0.27",org.apache.el.lang;version="10.0.27",org.apache.el.stream;v
 ersion="10.0.27",org.apache.el.parser;version="10.0.27",org.apache.el.u
 til;version="10.0.27"
Implementation-Version: 10.0.27
Import-Package: jakarta.servlet.jsp;version="3.0";resolution:=optional,j
 akarta.servlet.jsp.el;version="3.0";resolution:=optional,jakarta.servle
 t.jsp.tagext;version="3.0";resolution:=optional
Specification-Version: 3.0
Tool: Bnd-4.0.0.201805111645
```

**apache-jsp-<ver>.jar**

```
Manifest-Version: 1.0
Automatic-Module-Name: org.mortbay.apache.jasper
Bnd-LastModified: 1701872751931
Build-Jdk: 11.0.20.1
Built-By: joakim
Bundle-Classpath: .
Bundle-Description: A rebundling of Apache Tomcat Jasper to remove the t
 omcat server dependencies,    so that the JSP engine can be used by the
  Eclipse Jetty project.
Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
Bundle-ManifestVersion: 2
Bundle-Name: Mortbay Jasper
Bundle-RequiredExecutionEnvironment: JavaSE-1.7
Bundle-SymbolicName: org.mortbay.jasper.apache-jsp
Bundle-Version: 10.0.27
Created-By: Apache Maven Bundle Plugin
Export-Package: org.apache.juli.logging;version="10.0.27",org.apache.tom
 cat;version="10.0.27",org.apache.tomcat.util.compat;version="10.0.27",o
 rg.apache.tomcat.util.scan;version="10.0.27",org.apache.tomcat.util.fil
 e;version="10.0.27",org.apache.tomcat.util.digester;version="10.0.27",o
 rg.apache.tomcat.util.descriptor.tagplugin;version="10.0.27",org.apache
 .tomcat.util.descriptor.tld;version="10.0.27",org.apache.tomcat.util.de
 scriptor.web;version="10.0.27",org.apache.tomcat.util;version="10.0.27"
 ,org.apache.tomcat.util.buf;version="10.0.27",org.apache.tomcat.util.re
 s;version="10.0.27",org.apache.tomcat.util.security;version="10.0.27",j
 akarta.servlet.jsp;version="3.0",jakarta.servlet.jsp.el;version="3.0",j
 akarta.servlet.jsp.tagext;version="3.0",jakarta.servlet.jsp.resources;v
 ersion="3.0",org.apache.jasper;version="10.0.27",org.apache.jasper.comp
 iler;version="10.0.27",org.apache.jasper.compiler.tagplugin;version="10
 .0.27",org.apache.jasper.el;version="10.0.27",org.apache.jasper.resourc
 es;version="10.0.27",org.apache.jasper.runtime;version="10.0.27",org.ap
 ache.jasper.security;version="10.0.27",org.apache.jasper.servlet;versio
 n="10.0.27",org.apache.jasper.tagplugins.jstl;version="10.0.27",org.apa
 che.jasper.tagplugins.jstl.core;version="10.0.27",org.apache.jasper.uti
 l;version="10.0.27",org.apache.jasper.xmlparser;version="10.0.27"
Implementation-Version: 10.0.27
Import-Package: jakarta.el;version="4.0",javax.naming,javax.net.ssl,jaka
 rta.servlet;version="5.0",jakarta.servlet.annotation;version="5.0",jaka
 rta.servlet.descriptor;version="5.0",jakarta.servlet.http;version="5.0"
 ,jakarta.servlet.resources;version="5.0",javax.xml.parsers,org.apache.e
 l.util;version="[10.0,11)",org.apache.tomcat.util.descriptor;version="1
 0.0.0";resolution:=optional,org.apache.tomcat.util.descriptor.tagplugin
 ;version="10.0.0";resolution:=optional,org.eclipse.jdt.core.compiler,or
 g.eclipse.jdt.internal.compiler,org.eclipse.jdt.internal.compiler.class
 fmt,org.eclipse.jdt.internal.compiler.env,org.eclipse.jdt.internal.comp
 iler.impl,org.eclipse.jdt.internal.compiler.problem,org.xml.sax,org.xml
 .sax.ext,org.xml.sax.helpers
Require-Capability: osgi.serviceloader;filter:="(osgi.serviceloader=org.
 apache.juli.logging.Log)";resolution:=optional;cardinality:=multiple,os
 gi.extender;filter:="(osgi.extender=osgi.serviceloader.processor)"
Specification-Version: 2.3
Tool: Bnd-4.0.0.201805111645
```

Fixes #193