### PR TITLE
`apache-10.1.x` : Bumping maven-bundle-plugin to 5.1.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>4.0.0</version>
+          <version>5.1.9</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Bumping maven-bundle-plugin to v5.1.9

Here's the manifests.

### `apache-jsp-<ver>.jar` original (using m-bundle-p 4.0.0 on JDK11)

```
Manifest-Version: 1.0
Automatic-Module-Name: org.mortbay.apache.jasper
Bnd-LastModified: 1702062199283
Build-Jdk: 1.8.0_382
Built-By: joakim
Bundle-Classpath: .
Bundle-Description: A rebundling of Apache Tomcat Jasper to remove the t
 omcat server dependencies,    so that the JSP engine can be used by the
  Eclipse Jetty project.
Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
Bundle-ManifestVersion: 2
Bundle-Name: Mortbay Jasper
Bundle-RequiredExecutionEnvironment: JavaSE-1.7
Bundle-SymbolicName: org.mortbay.jasper.apache-jsp
Bundle-Version: 9.0.52
Created-By: Apache Maven Bundle Plugin
Export-Package: org.apache.juli.logging;version="9.0.52",org.apache.tomc
 at;version="9.0.52",org.apache.tomcat.util.compat;version="9.0.52",org.
 apache.tomcat.util.scan;version="9.0.52",org.apache.tomcat.util.file;ve
 rsion="9.0.52",org.apache.tomcat.util.digester;version="9.0.52",org.apa
 che.tomcat.util.descriptor.tagplugin;version="9.0.52",org.apache.tomcat
 .util.descriptor.tld;version="9.0.52",org.apache.tomcat.util.descriptor
 .web;version="9.0.52",org.apache.tomcat.util;version="9.0.52",org.apach
 e.tomcat.util.buf;version="9.0.52",org.apache.tomcat.util.res;version="
 9.0.52",org.apache.tomcat.util.security;version="9.0.52",javax.servlet.
 jsp;version="2.3",javax.servlet.jsp.el;version="2.3",javax.servlet.jsp.
 tagext;version="2.3",javax.servlet.jsp.resources;version="2.3",org.apac
 he.jasper;version="9.0.52",org.apache.jasper.compiler;version="9.0.52",
 org.apache.jasper.compiler.tagplugin;version="9.0.52",org.apache.jasper
 .el;version="9.0.52",org.apache.jasper.resources;version="9.0.52",org.a
 pache.jasper.runtime;version="9.0.52",org.apache.jasper.security;versio
 n="9.0.52",org.apache.jasper.servlet;version="9.0.52",org.apache.jasper
 .tagplugins.jstl;version="9.0.52",org.apache.jasper.tagplugins.jstl.cor
 e;version="9.0.52",org.apache.jasper.util;version="9.0.52",org.apache.j
 asper.xmlparser;version="9.0.52"
Implementation-Version: 9.0.52
Import-Package: javax.el;version="3.0",javax.naming,javax.net.ssl,javax.
 servlet;version="4.0.0",javax.servlet.annotation;version="4.0.0",javax.
 servlet.descriptor;version="4.0.0",javax.servlet.http;version="4.0.0",j
 avax.servlet.resources;version="4.0.0",javax.xml.parsers,org.apache.el.
 util;version="[9.0,10)",org.apache.tomcat.util.descriptor;version="9.0.
 14";resolution:=optional,org.apache.tomcat.util.descriptor.tagplugin;ve
 rsion="9.0.14";resolution:=optional,org.eclipse.jdt.core.compiler,org.e
 clipse.jdt.internal.compiler,org.eclipse.jdt.internal.compiler.classfmt
 ,org.eclipse.jdt.internal.compiler.env,org.eclipse.jdt.internal.compile
 r.impl,org.eclipse.jdt.internal.compiler.problem,org.xml.sax,org.xml.sa
 x.ext,org.xml.sax.helpers
Require-Capability: osgi.serviceloader;filter:="(osgi.serviceloader=org.
 apache.juli.logging.Log)";resolution:=optional;cardinality:=multiple,os
 gi.extender;filter:="(osgi.extender=osgi.serviceloader.processor)"
Specification-Version: 2.3
Tool: Bnd-4.0.0.201805111645
```

### `apache-jsp-<ver>.jar` diff (using m-bundle-p 5.1.9)

``` diff
--- apache-jsp-10.1.x-felix-4.0.0-manifest-jdk11.txt	2017-11-27 18:21:29.000000000 -0600
+++ apache-jsp-10.1.x-felix-5.1.9-manifest-jdk17.txt	2017-11-27 18:21:29.000000000 -0600
@@ -1,8 +1,7 @@
 Manifest-Version: 1.0
 Automatic-Module-Name: org.mortbay.apache.jasper
-Bnd-LastModified: 1702063513281
-Build-Jdk: 11.0.20.1
-Built-By: joakim
+Bnd-LastModified: 1702063590109
+Build-Jdk-Spec: 17
 Bundle-Classpath: .
 Bundle-Description: A rebundling of Apache Tomcat Jasper to remove the t
  omcat server dependencies,    so that the JSP engine can be used by the
@@ -13,7 +12,7 @@
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: org.mortbay.jasper.apache-jsp
 Bundle-Version: 10.1.0
-Created-By: Apache Maven Bundle Plugin
+Created-By: Apache Maven Bundle Plugin 5.1.9
 Export-Package: jakarta.servlet.jsp.resources;version="3.1",org.apache.j
  uli.logging;version="10.1.7",org.apache.tomcat;version="10.1.7",org.apa
  che.tomcat.util.compat;version="10.1.7",org.apache.tomcat.util.scan;ver
@@ -46,4 +45,4 @@
  apache.juli.logging.Log)";resolution:=optional;cardinality:=multiple,os
  gi.extender;filter:="(osgi.extender=osgi.serviceloader.processor)"
 Specification-Version: 3.1.0
-Tool: Bnd-4.0.0.201805111645
+Tool: Bnd-6.3.1.202206071316
```

### `apache-el-<ver>.jar` original (using m-bundle-p 4.0.0 on JDK11)

```
Manifest-Version: 1.0
Automatic-Module-Name: org.mortbay.apache.jasper
Bnd-LastModified: 1702063513281
Build-Jdk: 11.0.20.1
Built-By: joakim
Bundle-Classpath: .
Bundle-Description: A rebundling of Apache Tomcat Jasper to remove the t
 omcat server dependencies,    so that the JSP engine can be used by the
  Eclipse Jetty project.
Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
Bundle-ManifestVersion: 2
Bundle-Name: Mortbay Jasper
Bundle-RequiredExecutionEnvironment: JavaSE-1.7
Bundle-SymbolicName: org.mortbay.jasper.apache-jsp
Bundle-Version: 10.1.0
Created-By: Apache Maven Bundle Plugin
Export-Package: jakarta.servlet.jsp.resources;version="3.1",org.apache.j
 uli.logging;version="10.1.7",org.apache.tomcat;version="10.1.7",org.apa
 che.tomcat.util.compat;version="10.1.7",org.apache.tomcat.util.scan;ver
 sion="10.1.7",org.apache.tomcat.util.file;version="10.1.7",org.apache.t
 omcat.util.digester;version="10.1.7",org.apache.tomcat.util.descriptor.
 tagplugin;version="10.1.7",org.apache.tomcat.util.descriptor.tld;versio
 n="10.1.7",org.apache.tomcat.util.descriptor.web;version="10.1.7",org.a
 pache.tomcat.util;version="10.1.7",org.apache.tomcat.util.buf;version="
 10.1.7",org.apache.tomcat.util.res;version="10.1.7",org.apache.tomcat.u
 til.security;version="10.1.7",org.apache.jasper;version="10.1.7",org.ap
 ache.jasper.compiler;version="10.1.7",org.apache.jasper.compiler.tagplu
 gin;version="10.1.7",org.apache.jasper.el;version="10.1.7",org.apache.j
 asper.resources;version="10.1.7",org.apache.jasper.runtime;version="10.
 1.7",org.apache.jasper.security;version="10.1.7",org.apache.jasper.serv
 let;version="10.1.7",org.apache.jasper.tagplugins.jstl;version="10.1.7"
 ,org.apache.jasper.tagplugins.jstl.core;version="10.1.7",org.apache.jas
 per.util;version="10.1.7",org.apache.jasper.xmlparser;version="10.1.7"
Implementation-Version: 10.1.7
Import-Package: jakarta.el;version="5.0",javax.naming,javax.net.ssl,jaka
 rta.servlet;version="6.0",jakarta.servlet.annotation;version="6.0",jaka
 rta.servlet.descriptor;version="6.0",jakarta.servlet.http;version="6.0"
 ,jakarta.servlet.resources;version="6.0",jakarta.servlet.jsp;version="3
 .1",jakarta.servlet.jsp.el;version="3.1",jakarta.servlet.jsp.tagext;ver
 sion="3.1",javax.xml.parsers,org.apache.el.util;version="[10.1,11)",org
 .eclipse.jdt.core.compiler,org.eclipse.jdt.internal.compiler,org.eclips
 e.jdt.internal.compiler.classfmt,org.eclipse.jdt.internal.compiler.env,
 org.eclipse.jdt.internal.compiler.impl,org.eclipse.jdt.internal.compile
 r.problem,org.xml.sax,org.xml.sax.ext,org.xml.sax.helpers
Require-Capability: osgi.serviceloader;filter:="(osgi.serviceloader=org.
 apache.juli.logging.Log)";resolution:=optional;cardinality:=multiple,os
 gi.extender;filter:="(osgi.extender=osgi.serviceloader.processor)"
Specification-Version: 3.1.0
Tool: Bnd-4.0.0.201805111645
```

### `apache-el-<ver>.jar` diff (using m-bundle-p 5.1.9)

``` diff
--- apache-el-10.1.x-felix-4.0.0-manifest-jdk11.txt	2017-11-27 18:21:29.000000000 -0600
+++ apache-el-10.1.x-felix-5.1.9-manifest-jdk17.txt	2017-11-27 18:21:29.000000000 -0600
@@ -1,8 +1,7 @@
 Manifest-Version: 1.0
 Automatic-Module-Name: org.mortbay.apache.el
-Bnd-LastModified: 1702063511990
-Build-Jdk: 11.0.20.1
-Built-By: joakim
+Bnd-LastModified: 1702063589358
+Build-Jdk-Spec: 17
 Bundle-Classpath: .
 Bundle-Description: A rebundling of Apache Tomcat Jasper to remove the t
  omcat server dependencies,    so that the JSP engine can be used by the
@@ -13,7 +12,7 @@
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: org.mortbay.jasper.apache-el
 Bundle-Version: 10.1.0
-Created-By: Apache Maven Bundle Plugin
+Created-By: Apache Maven Bundle Plugin 5.1.9
 Export-Package: org.apache.el;version="10.1.7",org.apache.el.lang;versio
  n="10.1.7",org.apache.el.stream;version="10.1.7",org.apache.el.parser;v
  ersion="10.1.7",org.apache.el.util;version="10.1.7"
@@ -26,4 +25,4 @@
 Require-Capability: osgi.extender;filter:="(osgi.extender=osgi.servicelo
  ader.registrar)"
 Specification-Version: 5.0
-Tool: Bnd-4.0.0.201805111645
+Tool: Bnd-6.3.1.202206071316
```
